### PR TITLE
Show examples for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.1](https://github.com/adobe/jsonschema2md/compare/v2.1.0...v2.1.1) (2019-05-29)
+
+
+### Bug Fixes
+
+* **package:** update async to version 3.0.1 ([4ffa21e](https://github.com/adobe/jsonschema2md/commit/4ffa21e))
+
 # [2.1.0](https://github.com/adobe/jsonschema2md/compare/v2.0.0...v2.1.0) (2019-04-30)
 
 

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -248,10 +248,16 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
     //regular properties
     for (let i=0; i<_.keys(schema.properties).length;i++) {
       const name = _.keys(schema.properties).sort()[i];
+
+      var examples = schema.properties[name]['examples'];
+      if (!examples && schema.properties[name]['items']) {
+        examples = schema.properties[name]['items']['examples'];
+      }
+
       multi.push( [ 'property.ejs', {
         name: name,
         required: schema.required ? schema.required.includes(name) : false,
-        examples: stringifyExamples(schema.properties[name]['examples']),
+        examples: stringifyExamples(examples),
         ejs: ejsRender,
         schema: simpletype(schema.properties[name]),
         nameSlug: propertiesSlugs[name]

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,12 +502,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
-      "requires": {
-        "lodash": "^4.17.10"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+      "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
     },
     "atob": {
       "version": "2.1.2",
@@ -2260,6 +2257,15 @@
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8796,6 +8802,16 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        }
       }
     },
     "winston-transport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -504,7 +504,7 @@
     "async": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
-      "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
+      "integrity": "sha1-3+s0ZX0eY8lMDu5CQpe/iiyagYI="
     },
     "atob": {
       "version": "2.1.2",
@@ -2260,7 +2260,7 @@
         "async": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
           "dev": true,
           "requires": {
             "lodash": "^4.17.11"
@@ -8807,7 +8807,7 @@
         "async": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
           "requires": {
             "lodash": "^4.17.11"
           }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "ajv": "^6.5.4",
-    "async": "^2.0.1",
+    "async": "^3.0.1",
     "bluebird": "^3.5.4",
     "ejs": "^2.4.2",
     "github-slugger": "^1.2.1",

--- a/templates/md/object-type.ejs
+++ b/templates/md/object-type.ejs
@@ -11,7 +11,11 @@
 
 <% _.keys(schema.properties).sort().forEach(property => {
   const inner = schema.properties[property];
-  simpletype(inner)
+  simpletype(inner);
+  var examples = inner.examples;
+  if (!examples && inner.items) {
+    examples = inner.items.examples;
+  }
   const required = (Array.isArray(schema.required)&&schema.required.indexOf(property)>=0); %>
 
 <%- include("nested-property",{
@@ -20,7 +24,7 @@
     name: property, 
     schema: inner,
     required: required,
-    examples: inner.examples,
+    examples: examples,
     nameSlug:nameSlug
   }) %>
 


### PR DESCRIPTION
Previously, arrays that were not objects wouldn't have their examples displayed, e.g.:
```
"array_with_examples": {
    "type": "array",
    "description": "My array with examples",
    "items": {
        "type": "string",
        "description": "Array items description",
        "examples": [
            "example1",
            "example2",
        ]
    }
},
```

Would be generated into:
```
## array_with_examples

My array with examples

`array_with_examples`

- is optional
- type: `string[]`
- defined in this schema

### array_with_examples Type

Array type: `string[]`

All items must be of the type: `string`

Array items description
```
I added some code to add the examples section to arrays, so it generates into:
```
## array_with_examples

My array with examples

`array_with_examples`

- is optional
- type: `string[]`
- defined in this schema

### array_with_examples Type

Array type: `string[]`

All items must be of the type: `string`

Array items description

### array_with_examples Examples

"example1"

"example2"

```